### PR TITLE
Avoid multiples in bases

### DIFF
--- a/e0001/multiples/calculator.go
+++ b/e0001/multiples/calculator.go
@@ -3,7 +3,10 @@
 // order and with no duplicates.
 package multiples
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // Calculator runs a gorutine that will calculate multiples as explained
 // in the package description.  It returns a channel where the multiples
@@ -25,11 +28,12 @@ func Calculator(bases []int, max int) (<-chan int, error) {
 	if err := checkMax(max); err != nil {
 		return nil, err
 	}
+	clean := cleanBases(bases)
 	c := calculator{
-		bases:     bases,
+		bases:     clean,
 		max:       max,
-		factors:   ones(uint(len(bases))),
-		multiples: make([]int, len(bases)),
+		factors:   ones(uint(len(clean))),
+		multiples: make([]int, len(clean)),
 	}
 	ret := make(chan int)
 	go func() {
@@ -59,6 +63,38 @@ func checkMax(m int) error {
 		return fmt.Errorf("invalid max (%d): it is not positive", m)
 	}
 	return nil
+}
+
+func cleanBases(bases []int) []int {
+	if len(bases) < 2 {
+		return bases
+	}
+	sorted := dup(bases)
+	sort.Sort(sort.IntSlice(sorted))
+	ret := make([]int, 1)
+	ret[0] = sorted[0]
+	for _, e := range sorted[1:] {
+		if isMultiple(e, ret) {
+			continue
+		}
+		ret = append(ret, e)
+	}
+	return ret
+}
+
+func dup(s []int) []int {
+	d := make([]int, len(s))
+	copy(d, s)
+	return d
+}
+
+func isMultiple(x int, s []int) bool {
+	for _, e := range s {
+		if x%e == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 type calculator struct {

--- a/e0001/multiples/calculator_test.go
+++ b/e0001/multiples/calculator_test.go
@@ -123,6 +123,11 @@ func TestCalculator(t *testing.T) {
 			bases:    []int{3, 5, 11, 2},
 			max:      7,
 			expected: []int{2, 3, 4, 5, 6},
+		}, {
+			name:     "lots of multiples in the bases",
+			bases:    []int{2, 4, 8},
+			max:      13,
+			expected: []int{2, 4, 6, 8, 10, 12},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/e0001/solution_test.go
+++ b/e0001/solution_test.go
@@ -32,3 +32,15 @@ func BenchmarkSolutionMaxIs100k(b *testing.B) {
 		solution([]int{3, 5}, 100000)
 	}
 }
+
+func BenchmarkSolutionManyMultiplesInBases(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		solution([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, 10000)
+	}
+}
+
+func BenchmarkSolutionNOMultiplesInBases(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		solution([]int{1}, 10000)
+	}
+}


### PR DESCRIPTION
When there are multiples in the bases, they don't contribute
in any way to the multiples generated by the calculator, but
the calculator will take a lot of time working with them.

This patch removes multiples from the bases before using
them in the calculator, so the run is much faster.